### PR TITLE
normalize path for windows compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var _ = require('lodash');
 var utf8 = require('is-utf8');
 var globby = require('globby');
 var metalsmith = require('./metalsmith.js');
+var normalize = require('normalize-path');
 
 var PLUGIN_NAME = 'gulp-metalsmith';
 
@@ -43,7 +44,7 @@ function plugin(opts) {
   }
 
   function processFile(file) {
-    var key = file.path.replace(file.base, '');
+    var key = normalize(file.path).replace(normalize(file.base, false), '');
     var contents = file.contents;
     var newFiles = {};
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-util": "^3.0.4",
     "is-utf8": "^0.2.1",
     "lodash": "^4.6.1",
+    "normalize-path": "^2.1.1",
     "through2": "^2.0.1",
     "vinyl-fs": "^2.4.2",
     "ware": "^1.2.0"


### PR DESCRIPTION
This patch normalizes the path so that plugins like `link.to` work on windows systems.